### PR TITLE
Allow empty value and let user to cancel current value

### DIFF
--- a/lib/components/Number.js
+++ b/lib/components/Number.js
@@ -15,6 +15,9 @@ const positiveValidation = value => {
 const integerValidation = value => parseFloat(value) % 1 === 0;
 
 const numberValidator = (decimal, negative) => value => {
+  if (value === '') {
+    return true;
+  }
   if (value === '-' && negative) {
     return true;
   }

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
   "prettier": {
     "printWidth": 100,
     "singleQuote": true,
-    "trailingComma": "es5"
+    "trailingComma": "es5",
+    "arrowParens": "avoid"
   },
   "husky": {
     "hooks": {

--- a/stories/Demo.js
+++ b/stories/Demo.js
@@ -99,6 +99,7 @@ const NumPadDemo = () => {
                   negative={false}
                   position="startTopLeft"
                   placeholder="Positive"
+                  value={state.positiveNumber}
                 >
                   <TextField label="Positive number" value={state.positiveNumber} />
                 </NumPad.Number>
@@ -196,12 +197,8 @@ const NumPadDemo = () => {
                   onChange={value => dispatch({ type: 'markers.calendar', value })}
                   dateFormat="DD.MM.YYYY"
                   markers={[
-                    moment()
-                      .subtract(4, 'days')
-                      .format('DD.MM.YYYY'),
-                    moment()
-                      .add(1, 'days')
-                      .format('DD.MM.YYYY'),
+                    moment().subtract(4, 'days').format('DD.MM.YYYY'),
+                    moment().add(1, 'days').format('DD.MM.YYYY'),
                   ]}
                   position="startTopLeft"
                 >


### PR DESCRIPTION
- Added prettier rule { "arrowParens": "avoid" } to avoid unexpected formatting code